### PR TITLE
Fixed error messages and SSL issues

### DIFF
--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -49,6 +49,8 @@ function Invoke-GetAutoDiscoverURL
     $Username = ""
   )
   try{
+    $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+    [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
     $domain = $Username.split("@")[1]
     $lyncurl = "https://lyncdiscover.$($domain)"
     write-host "[*] Using autodiscover URL of $($lyncurl)"
@@ -125,6 +127,8 @@ function Invoke-LyncSpray
   {
     write-host "[*] Retrieving S4B AutoDiscover Information"
     try{
+      $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+      [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
       $data = Invoke-WebRequest -Insecure -Uri $AutoDiscoverURL -Method GET -ContentType "application/json" -UseBasicParsing
       if(($data.content | ConvertFrom-JSON)._links.redirect)
       {
@@ -249,6 +253,8 @@ function Invoke-LyncBrute
   {
     write-host "[*] Retrieving S4B AutoDiscover Information"
     try{
+      $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+      [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
       $data = Invoke-WebRequest -Insecure -Uri $AutoDiscoverURL -Method GET -ContentType "application/json" -UseBasicParsing
       if(($data.content | ConvertFrom-JSON)._links.redirect)
       {
@@ -386,6 +392,8 @@ function Invoke-Authenticate
 
   try{
     $postParams = @{grant_type="password";username=$Username;password=$Password}
+    $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+    [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
     $data = Invoke-WebRequest -Uri "$baseurl/WebTicket/oauthtoken" -Method POST -Body $postParams -UseBasicParsing
     $authcwt = ($data.content | ConvertFrom-JSON).access_token
   }catch [Exception]{

--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -53,7 +53,7 @@ function Invoke-GetAutoDiscoverURL
     [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
     $domain = $Username.split("@")[1]
     $lyncurl = "https://lyncdiscover.$($domain)"
-    write-host "[*] Using autodiscover URL of $($lyncurl)"
+    write-verbose "[*] Using autodiscover URL of $($lyncurl)"
     $data = Invoke-WebRequest -Insecure -Uri $lyncurl -Method GET -ContentType "application/json" -UseBasicParsing
 
     if($data)
@@ -61,8 +61,7 @@ function Invoke-GetAutoDiscoverURL
       return $lyncurl;
     }
   }catch{
-    write-output "[*] Unable to get automatically retrieve autodiscover information, please specify"
-    exit 1
+    throw "Unable to get automatically retrieved autodiscover information, please specify"
   }
 }
 
@@ -162,9 +161,7 @@ function Invoke-LyncSpray
         $baseurl = (($data.content | ConvertFrom-JSON)._links.user.href).split("/")[0..2] -join "/"
       }
     }catch [Exception] {
-      echo $_.Exception.GetType().FullName, $_.Exception.Message
-      write-host "[*] Unable to retrieve or process AutoDiscover URL"
-      exit 1
+      throw "Unable to retrieve or process AutoDiscover URL: " + $_.Exception.GetType().FullName + " - " + $_.Exception.Message
     }
   }
 
@@ -288,9 +285,7 @@ function Invoke-LyncBrute
         $baseurl = (($data.content | ConvertFrom-JSON)._links.user.href).split("/")[0..2] -join "/"
       }
     }catch [Exception] {
-      echo $_.Exception.GetType().FullName, $_.Exception.Message
-      write-host "[*] Unable to retrieve or process AutoDiscover URL"
-      exit 1
+      throw "Unable to retrieve or process AutoDiscover URL: " + $_.Exception.GetType().FullName + " - " + $_.Exception.Message
     }
   }
 
@@ -397,8 +392,7 @@ function Invoke-Authenticate
     $data = Invoke-WebRequest -Uri "$baseurl/WebTicket/oauthtoken" -Method POST -Body $postParams -UseBasicParsing
     $authcwt = ($data.content | ConvertFrom-JSON).access_token
   }catch [Exception]{
-    echo $_.Exception.GetType().FullName, $_.Exception.Message
-    Write-Verbose "[*] Invalid credentials: $($Username):$($Password)"
+    Write-Verbose "[*] Invalid credentials: $($Username):$($Password)   (" + $_.Exception.GetType().FullName + " - " + $_.Exception.Message + ")"
     return
   }
   write-host -foreground "green" "[*] Found credentials: $($Username):$($Password)"


### PR DESCRIPTION
This pull request fixes two things:

1)  I ran into multiple "lyndiscover.domain.com" websites that used outdated encryptions of SSL certs.  This would cause all Invoke-WebRequest statements to fail with "Unknown sending error".  The addition of setting the "SecurityProtocol" to "Ssl,Tls,Tls11,Tls12" allows these outdated SSL certs to be accepted with no issue.  We don't much care about the SSL certificate strength when performing this attack, so I think the change is justified.

2) I converted all your "exit 1" statements to a proper throw.  The following was happening to me:

![](https://i.imgur.com/vHtW1i8.png)

I also moved your "Write-Host" statements located in error handling blocks to text of the exception thrown.  And I removed all those pesky "echo" statements!