### PR TITLE
Added 'clean up user list' functionality to Invoke-LyncSpray when using -Office365

### DIFF
--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -120,6 +120,7 @@ function Invoke-LyncSpray
 
   $Usernames = Get-Content $UserList
   $Username = $Usernames[0]
+  $InvalidUsernames = [System.Collections.ArrayList]@()
   if (-Not $AutoDiscoverURL)
   {
     Write-host "[*] No AutoDiscoverURL provided, attempting to discover"
@@ -187,6 +188,14 @@ function Invoke-LyncSpray
     {
         Start-Sleep -Milliseconds $Delay
     }
+  }
+  if($Office365)
+  {
+    OutputDir = Split-Path $Usernames
+    OutputFile = [System.IO.Path]::GetFileNameWithoutExtension($Usernames)
+    OutputFullPath = "${OutputDir}\${OutputFile}_clean.txt"
+    Write-Verbose "[*] Saving valid usernames to $OutputFullPath."
+    $ValidUsernames = $Usernames | Where {$InvalidUsernames -NotContains $_} > $OutputFullPath
   }
 }
 
@@ -512,6 +521,7 @@ function Invoke-AuthenticateO365
     else
     {
       Write-Verbose "[*] Authentication failed: $($Username):$($Password). Username does not exist."
+      $InvalidUsernames.Add($Username) | Out-Null
     }
 
   } catch {

--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -191,9 +191,9 @@ function Invoke-LyncSpray
   }
   if($Office365)
   {
-    OutputDir = Split-Path $Usernames
-    OutputFile = [System.IO.Path]::GetFileNameWithoutExtension($Usernames)
-    OutputFullPath = "${OutputDir}\${OutputFile}_clean.txt"
+    $OutputDir = Split-Path $UserList
+    $OutputFile = [System.IO.Path]::GetFileNameWithoutExtension($UserList)
+    $OutputFullPath = "${OutputDir}\${OutputFile}_validusers.txt"
     Write-Host "[*] Saving valid usernames to $OutputFullPath."
     $ValidUsernames = $Usernames | Where {$InvalidUsernames -NotContains $_} > $OutputFullPath
   }

--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -189,12 +189,12 @@ function Invoke-LyncSpray
         Start-Sleep -Milliseconds $Delay
     }
   }
-  if($Office365)
+  if($Office365 -And ($InvalidUsernames.Count -gt 0))
   {
     $OutputDir = Split-Path $UserList
     $OutputFile = [System.IO.Path]::GetFileNameWithoutExtension($UserList)
     $OutputFullPath = "${OutputDir}\${OutputFile}_validusers.txt"
-    Write-Host "[*] Saving valid usernames to $OutputFullPath."
+    Write-Host -Foreground Yellow "[*] Saving valid usernames to $OutputFullPath."
     $ValidUsernames = $Usernames | Where {$InvalidUsernames -NotContains $_} > $OutputFullPath
   }
 }

--- a/LyncSniper.ps1
+++ b/LyncSniper.ps1
@@ -194,7 +194,7 @@ function Invoke-LyncSpray
     OutputDir = Split-Path $Usernames
     OutputFile = [System.IO.Path]::GetFileNameWithoutExtension($Usernames)
     OutputFullPath = "${OutputDir}\${OutputFile}_clean.txt"
-    Write-Verbose "[*] Saving valid usernames to $OutputFullPath."
+    Write-Host "[*] Saving valid usernames to $OutputFullPath."
     $ValidUsernames = $Usernames | Where {$InvalidUsernames -NotContains $_} > $OutputFullPath
   }
 }


### PR DESCRIPTION
Thanks for the awesome tool guys!

I saw when using the -Office365 flag you could determine which users did not exist. I added some functionality to track which users do not exist and to create a clean list of valid users after your spray attempt.

Saves you time in the future by cleaning out invalid usernames and then you can use this list of confirmed users to kick off other SE attacks. Something that helped me in a recent engagement, feel free to merge if you think it would be a good addition!